### PR TITLE
Add enum to user tattoos

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,7 +13,7 @@ class User < ApplicationRecord
   has_secure_password
 
   def find_user_tatts
-    tattoos
+    tattoos.where("status = 0")
   end
 
   def find_user_identities

--- a/app/models/user_tattoo.rb
+++ b/app/models/user_tattoo.rb
@@ -6,4 +6,6 @@ class UserTattoo < ApplicationRecord
   belongs_to :user
   belongs_to :tattoo
 
+  enum status: ["liked", "disliked"]
+
 end

--- a/db/migrate/20240411153210_add_column_to_user_tattoos.rb
+++ b/db/migrate/20240411153210_add_column_to_user_tattoos.rb
@@ -1,0 +1,5 @@
+class AddColumnToUserTattoos < ActiveRecord::Migration[7.1]
+  def change
+    add_column :user_tattoos, :status, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_11_032459) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_11_153210) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -90,6 +90,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_11_032459) do
     t.bigint "tattoo_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status"
     t.index ["tattoo_id"], name: "index_user_tattoos_on_tattoo_id"
     t.index ["user_id"], name: "index_user_tattoos_on_user_id"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -56,7 +56,7 @@ users = User.all
 
 # create user_tattoos
 users.each do |user|
-  UserTattoo.create!({user_id: user.id, tattoo_id: Tattoo.last.id})
+  UserTattoo.create!({user_id: user.id, tattoo_id: Tattoo.last.id, status: 0})
 end
 
 # create user_identities

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe User, type: :model do
     @tattoo_2 = Tattoo.create!({artist_id: @artist.id, price: 350, time_estimate: 100, image_url: "image/path"})
     @tattoo_3 = Tattoo.create!({artist_id: @artist.id, price: 150, time_estimate: 60, image_url: "image/path"})
 
-    @user_tattoo_1 = UserTattoo.create!({tattoo_id: @tattoo_1.id, user_id: @user_1.id})
-    @user_tattoo_2 = UserTattoo.create!({tattoo_id: @tattoo_2.id, user_id: @user_1.id})
+    @user_tattoo_1 = UserTattoo.create!({tattoo_id: @tattoo_1.id, user_id: @user_1.id, status: 0})
+    @user_tattoo_2 = UserTattoo.create!({tattoo_id: @tattoo_2.id, user_id: @user_1.id, status: 0})
 
     @user_identity_1 = UserIdentity.create!({user_id: @user_1.id, identity_id: @identity_1.id})
     @user_identity_2 = UserIdentity.create!({user_id: @user_1.id, identity_id: @identity_2.id})

--- a/spec/models/user_tattoo_spec.rb
+++ b/spec/models/user_tattoo_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe UserTattoo, type: :model do
     it { should belong_to :tattoo }
   end
 
-  describe 'instance methods' do
+  describe 'enums' do
+    it { should define_enum_for(:status).with_values(["liked", "disliked"]) }
   end
 end

--- a/spec/requests/api/v0/user_tattoos/get_all_user_tattoos_spec.rb
+++ b/spec/requests/api/v0/user_tattoos/get_all_user_tattoos_spec.rb
@@ -10,14 +10,15 @@ RSpec.describe "Get all UserTattoos via GET HTTP Request" do
     @tattoo_2 = Tattoo.create!({artist_id: @artist.id, price: 350, time_estimate: 100, image_url: "image/path"})
     @tattoo_3 = Tattoo.create!({artist_id: @artist.id, price: 150, time_estimate: 60, image_url: "image/path"})
 
-    @user_tattoo_1 = UserTattoo.create!({tattoo_id: @tattoo_1.id, user_id: @user_1.id})
-    @user_tattoo_2 = UserTattoo.create!({tattoo_id: @tattoo_2.id, user_id: @user_1.id})
+    @user_tattoo_1 = UserTattoo.create!({tattoo_id: @tattoo_1.id, user_id: @user_1.id, status: 0})
+    @user_tattoo_2 = UserTattoo.create!({tattoo_id: @tattoo_2.id, user_id: @user_1.id, status: 0})
+    @user_tattoo_3 = UserTattoo.create!({tattoo_id: @tattoo_3.id, user_id: @user_1.id, status: 1})
 
     @headers = {"CONTENT_TYPE" => "application/json"}
   end
 
   describe '#happy path' do
-    it 'will return all tattoos that are associated with the given user' do
+    it 'will return all tattoos that are associated with the given user with a liked status' do
       get "/api/v0/users/#{@user_1.id}/tattoos", headers: @headers
 
       expect(response).to be_successful


### PR DESCRIPTION
## Type of change
- [x] New feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Styling
- [ ] Documentation
- [ ] Other:

## Description
Relevant User Story(s): 
This branch adds the following:
- Adds enum "status" to user tattoos for liked and disliked tattoos to allow for tattoos that have been liked to show up on a users tattoos page and disliked tattoos to be avoided when showing users new tattoos

## Necessary checkmarks:
- [x] All Tests are Passing
- [x] The code will run locally
- [x] Unnecessary comments removed
- [x] Test coverage 100%

## Any Outstanding Issues/Problems?
- [x] My code is wonderful, no issues here!
- [ ] Yeah, see additional words below
