### PR TITLE
Aws s3 image upload

### DIFF
--- a/app/controllers/api/v0/tattoos_controller.rb
+++ b/app/controllers/api/v0/tattoos_controller.rb
@@ -5,4 +5,18 @@ class Api::V0::TattoosController < ApplicationController
     render json: TattoosSerializer.new(tattoo)
   end
 
+  def create
+    tattoo = Tattoo.new(tattoo_params)
+    if tattoo.save 
+      render json: TattoosSerializer.new(tattoo)
+    else
+      render json: {error: "Tattoo could not be uploaded"}, status: 422
+    end
+  end
+
+  private
+
+  def tattoo_params
+    params.permit(:"artist_id", :"image_url", :"price", :"time_estimate")
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,7 @@ Rails.application.routes.draw do
         resources :tattoos, only: [:index], controller: "artist_tattoos"
         resources :identities, only: [:index, :destroy], controller: "artist_identities"
       end
-      resources :tattoos, only: [:show]
+      resources :tattoos, only: [:show, :create]
       post "/sign_in", to: "sign_in#verify_sign_in"
 
       resources :user_identities, only: [:create]

--- a/spec/requests/api/v0/tattoos/create_new_tattoo_spec.rb
+++ b/spec/requests/api/v0/tattoos/create_new_tattoo_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe 'Create New Tattoo via POST HTTP Request' do
+  before(:each) do
+    @artist = create(:artist)
+
+    @params = {price: 90, time_estimate: 120, artist_id: @artist.id, image_url: "test/url/path"}
+    @bad_params = {price: 90, time_estimate: 120, artist_id: @artist.id}
+  end
+
+  describe '#happy path' do
+    it 'can create a new tattoo record with all attributes via post http request' do
+      post "/api/v0/tattoos", params: @params
+
+      expect(response).to be_successful
+
+      response_data = JSON.parse(response.body, symbolize_names: true)
+
+      check_hash_structure(response_data, :data, Hash)
+      check_hash_structure(response_data[:data], :id, String)
+      attributes = response_data[:data][:attributes]
+
+      expect(attributes[:image_url]).to eq(@params[:image_url])
+      expect(attributes[:price]).to eq(@params[:price])
+      expect(attributes[:time_estimate]).to eq(@params[:time_estimate])
+      expect(attributes[:artist_id]).to eq(@params[:artist_id])
+    end
+  end
+
+  describe '#sad path' do
+    it 'returns the correct resopnse when uploading a tattoo with incorrect parameters' do
+      post "/api/v0/tattoos", params: @bad_params
+
+      expect(response).not_to be_successful
+
+      error = JSON.parse(response.body, symbolize_names: true)
+
+      expect(error).to have_key(:error)
+      expect(error[:error]).to eq("Tattoo could not be uploaded")
+    end
+  end
+end


### PR DESCRIPTION
## Type of change
- [x] New feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Styling
- [ ] Documentation
- [ ] Other:

## Description
Relevant User Story(s): 
This branch adds the endpoint POST "/api/v0/tattoos" where the body is tattoo attributes including the aws-s3 storage url link.

In order to get the aws-s3 storage url to be created we will need to do the following in the TattoosController on the FE application after adding the keys, credentials, and configurations to connect aws-s3 to our app and have ActiveStorage upload the files:

- Activate ActiveStorage db tables on FE app
- Add a Blob.new.create_and_upload to the TattoosController create action utilizing the file fed in through 'new' form
- ActiveStorage blob will create the aws-s3 connection to upload the file and return a link to the file in its new storage location
- Send new image_url and other tattoo attributes from form fields in POST http request body to backend api

## Issue(s):
closes #60 

## Necessary checkmarks:
- [x] All Tests are Passing
- [x] The code will run locally
- [x] Unnecessary comments removed
- [x] Test coverage 100%

## Any Outstanding Issues/Problems?
- [x] My code is wonderful, no issues here!
- [ ] Yeah, see additional words below