### PR TITLE
Sign out and delete user disliked tattoos

### DIFF
--- a/app/controllers/api/v0/sign_out_controller.rb
+++ b/app/controllers/api/v0/sign_out_controller.rb
@@ -1,0 +1,19 @@
+class Api::V0::SignOutController < ApplicationController
+
+  def sign_out
+    if params[:user_id]
+      UserTattoo.delete_disliked_tattoos(sign_out_params[:user_id])
+      render status: 204
+    elsif params[:artist_id]
+      render status: 204
+    else
+      render status: 404
+    end
+  end
+
+  private
+  def sign_out_params
+    params.permit(:user_id, :artist_id)
+  end
+
+end

--- a/app/models/user_tattoo.rb
+++ b/app/models/user_tattoo.rb
@@ -8,4 +8,11 @@ class UserTattoo < ApplicationRecord
 
   enum status: ["liked", "disliked"]
 
+  def self.delete_disliked_tattoos(user_id)
+    disliked = self.where("status = 1 AND user_id = #{user_id}")
+    disliked.each do |user_tattoo|
+      user_tattoo.delete
+    end
+  end
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,9 @@ Rails.application.routes.draw do
         resources :identities, only: [:index, :destroy], controller: "artist_identities"
       end
       resources :tattoos, only: [:show, :create]
+
       post "/sign_in", to: "sign_in#verify_sign_in"
+      delete "/sign_out", to: "sign_out#sign_out"
 
       resources :user_identities, only: [:create]
       delete "/user_identities", to: "user_identities#destroy"

--- a/spec/models/user_tattoo_spec.rb
+++ b/spec/models/user_tattoo_spec.rb
@@ -14,4 +14,31 @@ RSpec.describe UserTattoo, type: :model do
   describe 'enums' do
     it { should define_enum_for(:status).with_values(["liked", "disliked"]) }
   end
+
+  describe '#class methods' do
+    describe '#delete_disliked_tattoos(user_id)' do
+      it 'can delete all UserTattoos with the status of 1 (disliked)' do
+        user = create(:user)
+        artist = create(:artist)
+
+        tattoo_1 = Tattoo.create!({price: 100, time_estimate: 90, artist_id: artist.id, image_url: "test/url/path"})
+        tattoo_2 = Tattoo.create!({price: 150, time_estimate: 90, artist_id: artist.id, image_url: "test/url/path"})
+        tattoo_3 = Tattoo.create!({price: 200, time_estimate: 90, artist_id: artist.id, image_url: "test/url/path"})
+
+        user_tattoo_1 = UserTattoo.create!({user_id: user.id, tattoo_id: tattoo_1.id, status: 1})
+        user_tattoo_2 = UserTattoo.create!({user_id: user.id, tattoo_id: tattoo_2.id, status: 1})
+        user_tattoo_3 = UserTattoo.create!({user_id: user.id, tattoo_id: tattoo_3.id, status: 0})
+
+        expect(user.tattoos.include?(tattoo_1)).to eq(true)
+        expect(user.tattoos.include?(tattoo_2)).to eq(true)
+        expect(user.tattoos.include?(tattoo_3)).to eq(true)
+
+        UserTattoo.delete_disliked_tattoos(user.id)
+
+        expect(user.tattoos.include?(tattoo_1)).to eq(false)
+        expect(user.tattoos.include?(tattoo_2)).to eq(false)
+        expect(user.tattoos.include?(tattoo_3)).to eq(true)
+      end
+    end
+  end
 end

--- a/spec/requests/api/v0/sign_out/artist_sign_out_spec.rb
+++ b/spec/requests/api/v0/sign_out/artist_sign_out_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe "Sign Artist Out via DELETE HTTP Request" do
+  before(:each) do
+    @artist = create(:artist)
+
+    @headers = {"CONTENT_TYPE" => "application/json"}
+
+    @sign_in_params = {
+      sign_in: {
+        email: @artist.email,
+        password: "Test",
+        type: "Sign In as Artist"
+      },
+      controller: "sessions",
+      action: "create"
+    }
+    @sign_out_params = {artist_id: @artist.id}
+    @bad_params = {}
+
+    post "/api/v0/sign_in", headers: @headers, params: JSON.generate(@sign_in_params)
+  end
+
+  describe '#happy path' do
+    it 'returns the correct status when sent valid parameters for signing out an artist' do
+      delete "/api/v0/sign_out", headers: @headers, params: JSON.generate(@sign_out_params)
+
+      expect(response).to be_successful
+      expect(response.status).to eq(204)
+    end
+  end
+
+  describe '#sad path' do
+    it 'returns the correct status when sent invalid parameters for signing out an artist' do
+      delete "/api/v0/sign_out", headers: @headers, params: JSON.generate(@bad_params)
+
+      expect(response).not_to be_successful
+      expect(response.status).to eq(404)
+    end
+  end
+end

--- a/spec/requests/api/v0/sign_out/user_sign_out_spec.rb
+++ b/spec/requests/api/v0/sign_out/user_sign_out_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe "Can Sign Out User via DELETE HTTP Request" do
+  before(:each) do
+    @user = create(:user, password: "Test")
+    @artist = create(:artist)
+
+    @tattoo_1 = Tattoo.create!({price: 100, time_estimate: 90, artist_id: @artist.id, image_url: "test/url/path"})
+    @tattoo_2 = Tattoo.create!({price: 150, time_estimate: 90, artist_id: @artist.id, image_url: "test/url/path"})
+    @tattoo_3 = Tattoo.create!({price: 200, time_estimate: 90, artist_id: @artist.id, image_url: "test/url/path"})
+
+    @user_tattoo_1 = UserTattoo.create!({tattoo_id: @tattoo_1.id, user_id: @user.id, status: 0})
+    @user_tattoo_2 = UserTattoo.create!({tattoo_id: @tattoo_2.id, user_id: @user.id, status: 1})
+    @user_tattoo_3 = UserTattoo.create!({tattoo_id: @tattoo_3.id, user_id: @user.id, status: 1})
+
+    @headers = {"CONTENT_TYPE" => "application/json"}
+
+    @sign_in_params = {
+      sign_in: {
+        email: @user.email,
+        password: "Test",
+        type: "Sign In as User"
+      },
+      controller: "sessions",
+      action: "create"
+    }
+    @sign_out_params = {user_id: @user.id}
+    @bad_params = {}
+
+    post "/api/v0/sign_in", headers: @headers, params: JSON.generate(@sign_in_params)
+  end
+
+  describe '#happy path' do
+    it 'can recieve the request and return a success for successfully siging out a user' do
+      delete "/api/v0/sign_out", headers: @headers, params: JSON.generate(@sign_out_params)
+
+      expect(response).to be_successful
+      expect(response.status).to eq(204)
+    end
+    
+    it 'can recieve the request and delete user_tattoos that have a disliked status' do
+      delete "/api/v0/sign_out", headers: @headers, params: JSON.generate(@sign_out_params)
+
+      expect(response).to be_successful
+      expect(@user.tattoos.include?(@tattoo_1)).to eq(true)
+      expect(@user.tattoos.include?(@tattoo_2)).to eq(false)
+      expect(@user.tattoos.include?(@tattoo_3)).to eq(false)
+    end
+  end
+
+  describe '#sad path' do
+    it 'will not log out the user if not given correct body information' do
+      delete "/api/v0/sign_out", headers: @headers, params: JSON.generate(@bad_params)
+
+      expect(response).not_to be_successful
+      expect(response.status).to eq(404)
+    end
+  end
+end


### PR DESCRIPTION
## Type of change
- [x] New feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Styling
- [ ] Documentation
- [ ] Other:

## Description
Relevant User Story(s): 
This branch adds the following endpoint:
DELETE "/api/v0/sign_out" - body accepts either user_id or artist_id depending on who is signing out
- If user is signing out, it removes records of disliked usertattoos so that they may show up again in the users feed (not sure if we want to keep this functionality, but we have it set this way for now.)

## Issue(s):
closes #47 

## Necessary checkmarks:
- [x] All Tests are Passing
- [x] The code will run locally
- [x] Unnecessary comments removed
- [x] Test coverage 100%

## Any Outstanding Issues/Problems?
- [x] My code is wonderful, no issues here!
- [ ] Yeah, see additional words below